### PR TITLE
Use Vault API from xp-framework/rfc#316

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Start the server:
 
 ```sh
 $ export HUDDLE_PASS=...
-$ xp web com.example.shorturl.Api
+$ xp web de.thekid.shorturl.Api
 ```
 
 Working with the service

--- a/src/main/php/de/thekid/shorturl/Api.class.php
+++ b/src/main/php/de/thekid/shorturl/Api.class.php
@@ -8,12 +8,13 @@ use util\log\ConsoleAppender;
 use util\log\LogLevel;
 use security\vault\Vault;
 use security\vault\FromEnvironment;
+use security\vault\FromFile;
 
 class Api implements \xp\scriptlet\WebLayout {
 
   /** @return [:xp.scriptlet.WebApplication] */
   public function mappedApplications($profile= null) {
-    $vault= new Vault(new FromEnvironment(FromEnvironment::REMOVE));
+    $vault= new Vault(new FromEnvironment(FromEnvironment::REMOVE), new FromFile('passwd'));
     $injector= new Injector(new SecretsIn($vault), new Bindings());
 
     if ('dev' === $profile) {

--- a/src/main/php/de/thekid/shorturl/Api.class.php
+++ b/src/main/php/de/thekid/shorturl/Api.class.php
@@ -6,12 +6,15 @@ use webservices\rest\srv\RestContext;
 use util\log\LogCategory;
 use util\log\ConsoleAppender;
 use util\log\LogLevel;
+use security\vault\Vault;
+use security\vault\FromEnvironment;
 
 class Api implements \xp\scriptlet\WebLayout {
 
   /** @return [:xp.scriptlet.WebApplication] */
   public function mappedApplications($profile= null) {
-    $injector= new Injector(new Bindings());
+    $vault= new Vault(new FromEnvironment(FromEnvironment::REMOVE));
+    $injector= new Injector(new SecretsIn($vault), new Bindings());
 
     if ('dev' === $profile) {
       $injector->get(RestContext::class)->setTrace((new LogCategory('web'))->withAppender(
@@ -20,6 +23,7 @@ class Api implements \xp\scriptlet\WebLayout {
       );
     }
 
+    $vault->close();
     return ['/' => $injector->get(WebApplication::class)];
   }
 

--- a/src/main/php/de/thekid/shorturl/Bindings.class.php
+++ b/src/main/php/de/thekid/shorturl/Bindings.class.php
@@ -6,11 +6,12 @@ use xp\scriptlet\WebApplication;
 use scriptlet\Filter;
 use webservices\rest\srv\RestContext;
 use webservices\rest\srv\RestScriptlet;
+use util\Secret;
 
 class Bindings extends \inject\Bindings {
 
   public function configure($injector) {
-    $pass= getenv('HUDDLE_PASS');
+    $pass= $injector->get(Secret::class, 'huddle_pass')->reveal();
 
     $conn= DriverManager::getConnection('mysql://huddle:'.$pass.'@127.0.0.1/HUDDLE');
     $injector->bind(DBConnection::class, $conn, 'huddle');

--- a/src/main/php/de/thekid/shorturl/SecretsIn.class.php
+++ b/src/main/php/de/thekid/shorturl/SecretsIn.class.php
@@ -1,0 +1,20 @@
+<?php namespace de\thekid\shorturl;
+
+use inject\Named;
+use inject\InstanceBinding;
+use security\vault\Vault;
+use util\Secret;
+
+class SecretsIn extends \inject\Bindings {
+  private $vault;
+
+  public function __construct(Vault $vault) { $this->vault= $vault; }
+
+  public function configure($injector) {
+    $vault= $this->vault;
+    $injector->bind(Secret::class, newinstance(Named::class, [], [
+      'provides' => function($name) { return true; },
+      'binding'  => function($name) use($vault) { return new InstanceBinding($vault->credential($name)); }
+    ]));
+  }
+}


### PR DESCRIPTION
Showcases integration with dependency injection. In essence, we create a named binding to the vault, wrapped in the `SecretsIn` bindings module. To fetch passwords, we then use:

``` php
$password= $injector->get(Secret::class, $name)->reveal(); 
```
