### PR TITLE
Use generics to simplify test code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
         php-version: ${{ matrix.php-versions }}
         ini-values: date.timezone=Europe/Berlin
 
-    - name: Setup Problem Matchers for PHP
-      run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-
     - name: Validate composer.json and composer.lock
       run: composer validate
 

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "xp-forge/rest-api": "^3.0",
     "xp-forge/web-auth": "^3.0",
     "xp-lang/php-compact-methods": "^1.0",
+    "xp-lang/xp-generics": "dev-feature/extend-generic-parent",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "xp-forge/rest-api": "^3.0",
     "xp-forge/web-auth": "^3.0",
     "xp-lang/php-compact-methods": "^1.0",
-    "xp-lang/xp-generics": "dev-feature/extend-generic-parent",
+    "xp-lang/xp-generics": "^0.5",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/src/test/php/de/thekid/shorturl/unittest/AdministrationTest.php
+++ b/src/test/php/de/thekid/shorturl/unittest/AdministrationTest.php
@@ -5,8 +5,7 @@ use test\{Assert, Test, Values};
 use web\Request;
 use web\io\TestInput;
 
-class AdministrationTest extends ApiTest {
-  protected static $fixture= Administration::class;
+class AdministrationTest extends ApiTest<Administration> {
   private const USER= ['id' => 'admin'];
 
   #[Test]

--- a/src/test/php/de/thekid/shorturl/unittest/ApiTest.php
+++ b/src/test/php/de/thekid/shorturl/unittest/ApiTest.php
@@ -1,6 +1,5 @@
 <?php namespace de\thekid\shorturl\unittest;
 
-use lang\Reflection;
 use test\Test;
 use web\Error;
 

--- a/src/test/php/de/thekid/shorturl/unittest/ApiTest.php
+++ b/src/test/php/de/thekid/shorturl/unittest/ApiTest.php
@@ -4,13 +4,13 @@ use test\Test;
 use web\Error;
 
 /** Base class */
-abstract class ApiTest {
+abstract class ApiTest<T> {
   protected const URLS= ['test' => 'https://example.com/', 'e8762e2' => 'https://test.example.com/'];
 
   /** Test helper */
   protected function test(function(object): mixed $call): array<int, mixed> {
     try {
-      $e= $call(new (static::$fixture)(new TestingUrls(self::URLS)))->export();
+      $e= $call($T->newInstance(new TestingUrls(self::URLS)))->export();
     } catch (Error $e) {
       $e= ['status' => $e->status(), 'body' => ['error' => ['message' => $e->getMessage()]]];
     }
@@ -23,6 +23,6 @@ abstract class ApiTest {
 
   #[Test]
   public function can_create() {
-    new (static::$fixture)(new TestingUrls());
+    $T->newInstance(new TestingUrls());
   }
 }

--- a/src/test/php/de/thekid/shorturl/unittest/PublicAccessTest.php
+++ b/src/test/php/de/thekid/shorturl/unittest/PublicAccessTest.php
@@ -4,8 +4,7 @@ use de\thekid\shorturl\api\PublicAccess;
 use peer\URL;
 use test\{Assert, Test, Values};
 
-class PublicAccessTest extends ApiTest {
-  protected static $fixture= PublicAccess::class;
+class PublicAccessTest extends ApiTest<PublicAccess> {
 
   #[Test, Values(['test', 'e8762e2'])]
   public function get_existing_sends_redirect($id) {


### PR DESCRIPTION
In a nutshell, this is the change from an authoring perspective:

```diff
- class AdministrationTest extends ApiTest {
-   protected static $fixture= Administration::class;
+ class AdministrationTest extends ApiTest<Administration> {
```

Made possible by xp-lang/xp-generics#5